### PR TITLE
Remove dummy Or gate - not necessary

### DIFF
--- a/projects/03/a/PC.hdl
+++ b/projects/03/a/PC.hdl
@@ -25,7 +25,5 @@ CHIP PC {
     Or(a=load, b=inc, out=loadOrInc);
     Or(a=loadOrInc, b=reset, out=loadOrIncOrReset);
     
-    Register(in=regInput, load=loadOrIncOrReset, out=regOutput);    
-    
-    Or16(a=false, b=regOutput, out=out); // dummy OR gate for output
+    Register(in=regInput, load=loadOrIncOrReset, out=regOutput, out=out);    
 }


### PR DESCRIPTION
A dummy Or gate is not necessary. It is possible to specify more than one output for the Register component. We can achieve the same function by simplify adding an additional output. This uses fewer components.