### PR TITLE
Make Mux8Way16.hdl more concise

### DIFF
--- a/projects/01/Mux8Way16.hdl
+++ b/projects/01/Mux8Way16.hdl
@@ -18,11 +18,7 @@ CHIP Mux8Way16 {
     OUT out[16];
 
     PARTS:
-    Mux16(a=a, b=b, sel=sel[0], out=outab);
-    Mux16(a=c, b=d, sel=sel[0], out=outcd);
-    Mux16(a=e, b=f, sel=sel[0], out=outef);
-    Mux16(a=g, b=h, sel=sel[0], out=outgh);
-    Mux16(a=outab, b=outcd, sel=sel[1], out=outabcd);
-    Mux16(a=outef, b=outgh, sel=sel[1], out=outefgh);
-    Mux16(a=outabcd, b=outefgh, sel=sel[2], out=out);
+    Mux4Way16(a=a, b=b, c=c, d=d, sel=sel[0..1], out=abcd);
+    Mux4Way16(a=e, b=f, c=g, d=h, sel=sel[0..1], out=efgh);
+    Mux16(a=abcd, b=efgh, sel=sel[2], out=out);
 }


### PR DESCRIPTION
Since the goal was set as to use as little chips as possible and since all previous chips are available, this seems like a more concise solution to me. Under the hood though, the number of used `Mux16` chips remain the same so unsure if my argument holds. Still wanted to share. Also, thanks for the awesome resources.